### PR TITLE
Bumped logback version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-actor"       % akkaV,
     "com.typesafe.akka" %% "akka-testkit"     % akkaV,
     "com.typesafe"      % "config"            % "1.2.1",
-    "ch.qos.logback"    % "logback-classic"   % "1.0.6"
+    "ch.qos.logback"    % "logback-classic"   % "1.1.2"
   ) ++ Seq(
     "org.specs2"        %%  "specs2"          % "2.3.13"    % "test",
     "org.scalatest"     %%  "scalatest"       % "2.1.6"     % "test->*"


### PR DESCRIPTION
Newer version of logback support SSL, the version of logback being so low in scamandrill causes my project that uses it to be unable to log via SSL
