### PR TITLE
To separate dispatcher from system.dispatcher.

### DIFF
--- a/src/main/scala/com/joypeg/scamandrill/client/MandrillAsyncClient.scala
+++ b/src/main/scala/com/joypeg/scamandrill/client/MandrillAsyncClient.scala
@@ -15,8 +15,6 @@ class MandrillAsyncClient(val system: ActorSystem = ActorSystem("scamandrill")) 
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   import com.joypeg.scamandrill.models.MandrillJsonProtocol._
 
-  implicit val ec = system.dispatcher
-
   /**
    * Asks all the underlying actors to close (waiting for 1 second)
    * and then shut down the system. Because the blocking client is

--- a/src/main/scala/com/joypeg/scamandrill/client/ScamandrillSendReceive.scala
+++ b/src/main/scala/com/joypeg/scamandrill/client/ScamandrillSendReceive.scala
@@ -5,10 +5,11 @@ import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
+import com.joypeg.scamandrill.models.DefaultConfig
 import com.joypeg.scamandrill.utils.SimpleLogger
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 /**
@@ -21,8 +22,7 @@ trait ScamandrillSendReceive extends SimpleLogger {
 
   implicit val system: ActorSystem
   implicit val materializer = ActorMaterializer()
-
-  import system.dispatcher
+  implicit val executionContext: ExecutionContext = DefaultConfig.defaultExecutionContext
 
 
   /**

--- a/src/main/scala/com/joypeg/scamandrill/models/DefaultConfig.scala
+++ b/src/main/scala/com/joypeg/scamandrill/models/DefaultConfig.scala
@@ -1,11 +1,19 @@
 package com.joypeg.scamandrill.models
 
-import scala.concurrent.duration._
+import akka.actor.ActorSystem
 import com.joypeg.scamandrill.utils._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 object DefaultConfig{
 
   lazy val defaultKeyFromConfig: String = config.getString("Mandrill.key")
   lazy val defaultTimeout: FiniteDuration = config.getInt("Mandrill.timoutInSeconds").seconds
-
+  def defaultExecutionContext(implicit system: ActorSystem): ExecutionContext = {
+    // TODO this may not be consistent with com.joypeg.scamandrill.utils.config
+    if (system.settings.config.hasPath("Mandrill.defaultDispatcher")) {
+      system.dispatchers.lookup("Mandrill.defaultDispatcher")
+    } else system.dispatcher
+  }
 }

--- a/src/test/scala/com/joypeg/scamandrill/MandrillTestUtils.scala
+++ b/src/test/scala/com/joypeg/scamandrill/MandrillTestUtils.scala
@@ -17,7 +17,7 @@ object MandrillTestUtils extends Matchers {
   val mandrillAsyncClient = new MandrillAsyncClient()
   val mandrillBlockingClient = new MandrillBlockingClient(mandrillAsyncClient.system)
   implicit val mat = mandrillAsyncClient.materializer
-  implicit val ec = mandrillAsyncClient.system.dispatcher
+  implicit val ec = mandrillAsyncClient.executionContext
 
 
   /**

--- a/src/test/scala/com/joypeg/scamandrill/models/DefaultConfigTest.scala
+++ b/src/test/scala/com/joypeg/scamandrill/models/DefaultConfigTest.scala
@@ -1,8 +1,12 @@
 package com.joypeg.scamandrill.models
 
-import org.scalatest.{Matchers, FlatSpec}
+import akka.actor.ActorSystem
 import com.joypeg.scamandrill.utils.SimpleLogger
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
 
 class DefaultConfigTest extends FlatSpec with Matchers with SimpleLogger {
 
@@ -13,5 +17,37 @@ class DefaultConfigTest extends FlatSpec with Matchers with SimpleLogger {
   it should "read the defaut timeout duration from the configuration" in {
     DefaultConfig.defaultTimeout.getClass shouldBe classOf[FiniteDuration]
     DefaultConfig.defaultTimeout shouldBe 10.seconds
+  }
+
+  it should "use defined dispatcher if configuration defined" in {
+    val config =
+      ConfigFactory.load()
+      .withFallback(ConfigFactory.parseString(
+        """
+          |Mandrill.defaultDispatcher {
+          |  type = Dispatcher
+          |  executor = "fork-join-executor"
+          |  fork-join-executor {
+          |    parallelism-min = 1
+          |    parallelism-max = 1
+          |  }
+          |}
+        """.stripMargin))
+    config.hasPath("Mandrill.defaultDispatcher") should equal(true)
+    val system = ActorSystem("test", config)
+
+    DefaultConfig.defaultExecutionContext(system) shouldNot equal(system.dispatcher)
+    Await.result(system.terminate(), 10 seconds)
+  }
+
+  it should "use system.dispatcher if configuration not defined" in {
+    val config =
+      ConfigFactory.load()
+
+    config.hasPath("Mandrill.defaultDispatcher") should equal(false)
+    val system = ActorSystem("test", config)
+
+    DefaultConfig.defaultExecutionContext(system) should equal(system.dispatcher)
+    Await.result(system.terminate(), 10 seconds)
   }
 }


### PR DESCRIPTION
Current implementation uses `system.dispatcher` for future's combinators. But I think it is preferable to separate it from system default for bulk-heading in a particular situation. (For example other implementation uses it for I/O operation by , but it is not preferable to affect to mandrill operation.)
